### PR TITLE
use quarkus-qbicc in sleep benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Other configuration parameters are documented in
 [Quarkus documentation](https://quarkus.io/guides/container-image#customizing).
 
 
-### Creating Native Executables (Optional)
+### Creating Native Executables using GraalVM (Optional)
 
 Native binary support is one of the major features of Quarkus.
 These benchmarks can be built as native binaries
@@ -71,6 +71,16 @@ a container image of the latest GraalVM with Native Image support and builds the
 in the container.  This automated containerized build is beneficial as
 it automatically uses the latest version of GraalVM, which is updated frequently.
 
+### Creating Native Executables Using qbicc (Optional)
+
+You can optionally build native binaries using [qbicc](https://github.com/qbicc/qbicc)
+by adding `-Pqbicc` to the Maven command line:
+```shell
+mvn package -Pqbicc
+```
+
+In the short term, you will need a local snapshot build of [quarkus-qbicc](https://github.com/qbicc/quarkus-qbicc),
+the Quarkus extension for compiling with qbicc.  We have not yet released a version of `quarkus-qbicc` to maven central. 
 
 ## Usage Instructions
 

--- a/benchmarks/clock-synchronization/pom.xml
+++ b/benchmarks/clock-synchronization/pom.xml
@@ -154,5 +154,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/benchmarks/compress/pom.xml
+++ b/benchmarks/compress/pom.xml
@@ -142,5 +142,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/benchmarks/dna-visualization/pom.xml
+++ b/benchmarks/dna-visualization/pom.xml
@@ -147,5 +147,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/benchmarks/dynamic-html/pom.xml
+++ b/benchmarks/dynamic-html/pom.xml
@@ -147,5 +147,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/benchmarks/graph-bfs/pom.xml
+++ b/benchmarks/graph-bfs/pom.xml
@@ -131,5 +131,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/benchmarks/graph-mst/pom.xml
+++ b/benchmarks/graph-mst/pom.xml
@@ -131,5 +131,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/benchmarks/graph-pagerank/pom.xml
+++ b/benchmarks/graph-pagerank/pom.xml
@@ -131,5 +131,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/benchmarks/image-recognition/pom.xml
+++ b/benchmarks/image-recognition/pom.xml
@@ -177,5 +177,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/benchmarks/network/pom.xml
+++ b/benchmarks/network/pom.xml
@@ -154,5 +154,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/benchmarks/server-reply/pom.xml
+++ b/benchmarks/server-reply/pom.xml
@@ -154,5 +154,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/benchmarks/sleep/pom.xml
+++ b/benchmarks/sleep/pom.xml
@@ -23,6 +23,10 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>org.qbicc.quarkus</groupId>
+      <artifactId>quarkus-qbicc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-funqy-knative-events</artifactId>
     </dependency>

--- a/benchmarks/sleep/pom.xml
+++ b/benchmarks/sleep/pom.xml
@@ -23,10 +23,6 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>org.qbicc.quarkus</groupId>
-      <artifactId>quarkus-qbicc</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-funqy-knative-events</artifactId>
     </dependency>
@@ -147,6 +143,15 @@
       <properties>
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
+    </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 </project>

--- a/benchmarks/thumbnailer/pom.xml
+++ b/benchmarks/thumbnailer/pom.xml
@@ -158,5 +158,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/benchmarks/uploader/pom.xml
+++ b/benchmarks/uploader/pom.xml
@@ -147,5 +147,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/benchmarks/video-processing/pom.xml
+++ b/benchmarks/video-processing/pom.xml
@@ -159,5 +159,14 @@
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
     </profile>
+    <profile>
+      <id>qbicc</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.qbicc.quarkus</groupId>
+          <artifactId>quarkus-qbicc</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <quarkus.platform.version>2.14.0.Final</quarkus.platform.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <qbicc.quarkus.version>1.0.0-SNAPSHOT</qbicc.quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -31,6 +32,11 @@
         <version>${quarkus.platform.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.qbicc.quarkus</groupId>
+        <artifactId>quarkus-qbicc</artifactId>
+        <version>${qbicc.quarkus.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This shouldn't be merged yet (as it requires a local build of quarkus-qbicc), but it shows how to wire things up.  After applying this, you can use the command ` mvn package -Dquarkus.container-image.build=false` and it will also invoke qbicc to compile the sleep benchmark.
